### PR TITLE
Codeblocks: minimal render hook, language pill; remove header/copy; GitHub Dark Default

### DIFF
--- a/layouts/_markup/render-codeblock.html
+++ b/layouts/_markup/render-codeblock.html
@@ -1,58 +1,18 @@
 {{- $lang := .Type | default "text" -}}
 {{- $options := .Attributes -}}
-{{- $ordinal := .Ordinal -}}
 
-{{- /* GitHub-style code block render hook */ -}}
-<div class="highlight highlight-{{ $lang }}" data-lang="{{ $lang }}">
-  <div class="code-header">
-    {{- if $lang -}}
-    <span class="code-lang">{{ $lang }}</span>
-    {{- end -}}
-    <button class="copy-button" data-copy-target="code-{{ $ordinal }}" aria-label="Copy to clipboard">
-      <svg class="copy-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M0 6.75A.75.75 0 01.75 6h1.5a.75.75 0 110 1.5h-.75v4.75c0 .414.336.75.75.75h4.5a.75.75 0 110 1.5H2.5A2.5 2.5 0 010 11.5V6.75zM5 1.75A.75.75 0 015.75 1h5.5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-2.75h-4.25A.75.75 0 015 1.75z"/>
-        <path d="M5 4.25A.75.75 0 015.75 3.5h5.5a.75.75 0 01.75.75v7a.75.75 0 01-.75.75h-5.5a.75.75 0 01-.75-.75v-7z"/>
-      </svg>
-    </button>
-  </div>
-  <pre class="github-code-block"><code id="code-{{ $ordinal }}" class="language-{{ $lang }}">
-    {{- highlight .Inner $lang (dict "style" "github" "lineNos" (index $options "lineNos") "hl_lines" (index $options "hl_lines") "lineNumbersInTable" true) | safeHTML -}}
-  </code></pre>
-</div>
+{{- /* Minimal GitHub-style code block: rely on Chroma HTML only */ -}}
+{{- highlight .Inner $lang (dict "style" "github" "lineNos" (index $options "lineNos") "hl_lines" (index $options "hl_lines") "lineNumbersInTable" true) | safeHTML -}}
 
-{{- /* JavaScript for copy functionality */ -}}
-{{- if not (.Page.Scratch.Get "github-codeblock-js") -}}
-  {{- .Page.Scratch.Set "github-codeblock-js" true -}}
-  <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    // Copy button functionality
-    document.querySelectorAll('.copy-button').forEach(button => {
-      button.addEventListener('click', function() {
-        const targetId = this.getAttribute('data-copy-target');
-        const codeElement = document.getElementById(targetId);
-
-        if (codeElement) {
-          // Get text content, excluding line numbers
-          const codeText = codeElement.querySelector('.chroma .lntd:last-child')?.textContent || codeElement.textContent;
-
-          navigator.clipboard.writeText(codeText.trim()).then(() => {
-            // Visual feedback
-            const icon = this.querySelector('.copy-icon');
-            const originalTitle = this.getAttribute('aria-label');
-
-            this.setAttribute('aria-label', 'Copied!');
-            icon.style.color = '#28a745';
-
-            setTimeout(() => {
-              this.setAttribute('aria-label', originalTitle);
-              icon.style.color = '';
-            }, 2000);
-          }).catch(err => {
-            console.error('Failed to copy text: ', err);
-          });
-        }
-      });
-    });
-  });
-  </script>
-{{- end -}}
+<script class="cb-init" data-lang="{{ $lang }}">
+(function(){
+  var s=document.currentScript; var h=s.previousElementSibling;
+  if(!h||!h.classList||!h.classList.contains('highlight')){ return; }
+  h.style.position='relative';
+  var tools=document.createElement('div'); tools.className='code-tools';
+  var lang=s.getAttribute('data-lang');
+  if(lang){ var lg=document.createElement('span'); lg.className='code-lang'; lg.textContent=lang; tools.appendChild(lg); }
+  h.insertBefore(tools, h.firstChild);
+  s.remove();
+})();
+</script>

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -75,15 +75,9 @@ html.dark .footer {
   border-color: #333;
 }
 
-/* Dark-mode code blocks: align with Monokai (Chroma default) */
-html.dark .highlight {
-  background-color: #272822;
-}
-html.dark .chroma,
-html.dark pre.chroma {
-  background-color: #272822;
-  color: #f8f8f2;
-}
+/* Dark-mode code blocks: GitHub Dark Default */
+html.dark .highlight { background-color: #0d1117; border-color: #30363d; }
+html.dark .chroma, html.dark pre.chroma { background-color: #0d1117; color: #f0f6fc; }
 
 html.dark .header .site-description .scheme-toggle a svg {
     fill: #f8e04f !important;

--- a/static/css/github-codeblocks.css
+++ b/static/css/github-codeblocks.css
@@ -14,75 +14,19 @@
   position: relative;
 }
 
-/* Code header with language label and copy button */
-.code-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 16px;
-  background-color: #f6f8fa;
-  border-bottom: 1px solid #d1d9e0;
-  min-height: 17px;
-}
-
-.code-lang {
-  font-size: 12px;
-  font-weight: 600;
-  color: #656d76;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.copy-button {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 4px;
-  color: #656d76;
-  border-radius: 4px;
-  transition: background-color 0.2s, color 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.copy-button:hover {
-  background-color: #e5e5e5;
-  color: #24292f;
-}
-
-.copy-button:active {
-  background-color: #d1d9e0;
-}
-
-.copy-icon {
-  width: 16px;
-  height: 16px;
-}
+/* Overlay tools inserted by render hook */
+.highlight { position: relative; }
+.highlight .code-tools { position: absolute; top: 8px; left: 8px; right: 8px; z-index: 1; }
+.highlight .code-lang { position: absolute; left: 0; top: 0; font: 12px/1 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; color: #7d8590; text-transform: uppercase; letter-spacing: .3px; background: rgba(0,0,0,0); padding: 2px 6px; border-radius: 6px; border: 1px solid #d1d9e0; }
+html.dark .highlight .code-lang { color: #7d8590; border-color: #30363d; }
 
 /* Pre and code styling */
-.github-code-block {
-  margin: 0;
-  padding: 16px;
-  background: transparent;
-  overflow-x: auto;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  color: #24292f;
-}
-
-.github-code-block code {
-  background: transparent;
-  padding: 0;
-  margin: 0;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  word-wrap: normal;
-  white-space: pre;
-  color: inherit;
-}
+/* Typography for Chroma output */
+.highlight .chroma pre { font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace; font-size: 14.5px; line-height: 1.6; padding: 16px; margin: 0; background: transparent; }
+.highlight .chroma .lntable .lntd:last-child pre { padding: 16px; }
+/* Make room for tools row */
+.highlight .chroma pre { padding-top: 34px; }
+.highlight .chroma .lntable .lntd:last-child pre { padding-top: 34px; }
 
 /* Chroma line number styling - GitHub style */
 .highlight .chroma .lnt,


### PR DESCRIPTION
- Render only Chroma HTML (.highlight→.chroma)
- Overlay language label inside .highlight (no header bar)
- Remove copy header/button to match RTJVM style; clean DOM
- Apply GitHub Light/Dark Default palettes (dark updated in dark.css)
- Typography & spacing applied to .chroma pre; top padding to avoid overlap

This keeps codeblocks fully theme-driven and removes need for site overrides.
